### PR TITLE
Utilize plugin for circus loading

### DIFF
--- a/lib/client/bootstrap.js.hbs
+++ b/lib/client/bootstrap.js.hbs
@@ -3,36 +3,22 @@
     return;
   }
 
-  var $cc = __webpack_components__.cc;
-  __webpack_components__.cc = function(componentName, initialChunks, requireFn) {
-    $cc(componentName, initialChunks, requireFn);
+  // Our loader. This lets us load circus chunks and components in response to an amd load
+  // operation. This is connected to the exports via the init interation defined in the
+  // segement below.
+  define('circus-chunk', {
+    load: function(name, req, onload) {
+      var match = /^(.+)_(\d+)$/.exec(name);
 
-    // Notify all of the pending AMD modules that this dependency is cleared
-    var nameBase = 'chunk_' + componentName;
-    define(nameBase + 0, function() {});
-    require([nameBase + 0]);
-  };
-
-  // Register any updates due to loading events within the jsonp handler
-  var $jsonp = window[{{jsonpFunction}}];
-  window[{{jsonpFunction}}] = function(componentName, chunkIds, chunkDeps, moreModules) {
-    $jsonp(componentName, chunkIds, chunkDeps, moreModules, function() {
-      var amdLoad = [];
-
-      for (var i = 0; i < chunkIds.length; i++) {
-        // Notify AMD that our chunk is loaded
-        var amdChunkName = 'chunk_' + componentName + chunkIds[i];
-        define(amdChunkName, function() {});
-        amdLoad.push(amdChunkName);
-      }
-
-      // This call is needed to force the above defines to be properly registered
-      // within the module system. require.js does not recognize `define` statements
-      // that occur in scripts that are loaded through external means, without a call
-      // such as this.
-      require(amdLoad);
-    });
-  };
+      // Load the component itself
+      loadComponent(match[1], function() {
+        // Load the chunk for this component
+        installedComponents[componentName].e(match[2], function() {
+          onload();
+        });
+      });
+    }
+  });
 
   // Report the modules that we export and what chunks must load to load them.
   for (var componentName in moduleExports) {
@@ -41,7 +27,7 @@
 
     for (var name in exports) {
       (function(componentName, name) {
-        define(name, ['chunk_' + componentName + chunks[exports[name]]], function() {
+        define(name, ['circus-chunk!' + componentName + '_' + chunks[exports[name]]], function() {
           return installedComponents[componentName](name);
         });
       })(componentName, name);

--- a/lib/index.js
+++ b/lib/index.js
@@ -34,7 +34,6 @@ module.exports.amdPaths = function(config, optimizer) {
 
     _.each(component.modules, function(module) {
       ret[module.name] = entry;
-      ret['chunk_' + componentName + module.chunk] = entry;
     });
   });
 

--- a/test/index.js
+++ b/test/index.js
@@ -132,10 +132,7 @@ describe('loader integration', function() {
 
         'vendor': 'vendor',
         'vendor/packages': 'vendor',
-        'vendor/require-packages': 'vendor',
-
-        'chunk_vendor0': 'vendor',
-        'chunk_vendor1': 'vendor'
+        'vendor/require-packages': 'vendor'
       });
 
       expect(CircusAMD.amdPaths(config, true)).to.eql({
@@ -150,10 +147,7 @@ describe('loader integration', function() {
 
         'vendor': 'empty:',
         'vendor/packages': 'empty:',
-        'vendor/require-packages': 'empty:',
-
-        'chunk_vendor0': 'empty:',
-        'chunk_vendor1': 'empty:'
+        'vendor/require-packages': 'empty:'
       });
 
       done();


### PR DESCRIPTION
Use a formal plugin for loading the circus components. This fixes potential
issues where chunks would not be loaded for a given require or they would be
loaded unnecessarily.

As an added benefit, this greatly simplifies the flow for AMD loading and
avoids one of the previously required hacks.