### PR TITLE
Update deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "homepage": "https://github.com/walmartlabs/circus-amd",
   "devDependencies": {
     "chai": "^1.10.0",
-    "circus": "^2.0.0",
+    "circus": "^4.1.0",
     "gulp": "^3.8.10",
     "gulp-istanbul": "^0.6.0",
     "gulp-jscs": "^1.4.0",

--- a/test/fixtures/require-packages.js
+++ b/test/fixtures/require-packages.js
@@ -1,3 +1,7 @@
+var log = document.createElement('log');
+log.info = 'circus module dependency should be first';
+document.body.appendChild(log);
+
 require.ensure('./packages', function() {
   require('./packages');
 });

--- a/test/index.js
+++ b/test/index.js
@@ -26,11 +26,11 @@ describe('loader integration', function() {
       var html = fs.readFileSync(__dirname + '/client/initial-route.html');
       fs.writeFileSync(outputDir + '/index.html', html);
 
-    var require = fs.readFileSync(__dirname + '/client/require.js');
-    fs.writeFileSync(outputDir + '/require.js', require);
+      var require = fs.readFileSync(__dirname + '/client/require.js');
+      fs.writeFileSync(outputDir + '/require.js', require);
 
-    var exec = fs.readFileSync(__dirname + '/fixtures/amd-exec.js');
-    fs.writeFileSync(outputDir + '/exec.js', exec);
+      var exec = fs.readFileSync(__dirname + '/fixtures/amd-exec.js');
+      fs.writeFileSync(outputDir + '/exec.js', exec);
 
       done();
     });
@@ -98,10 +98,15 @@ describe('loader integration', function() {
           expect(loaded.scripts[3]).to.match(/require.js$/);
           expect(loaded.scripts[4]).to.match(/exec.js$/);
 
-          expect(loaded.log).to.eql([
-            '_: true Handlebars: true',
-            'App: _: true Handlebars: true Vendor: true'
-          ]);
+          // The root-level webpack module should always run first.
+          expect(loaded.log[0]).to.eql("circus module dependency should be first");
+
+          // The logs below are added within functions that run asynchronously at about
+          // the same time.  Since order may not be deterministic, just assert that both
+          // are present by the time things wrap up.
+          expect(loaded.log)
+            .to.contain('_: true Handlebars: true').and
+            .to.contain('App: _: true Handlebars: true Vendor: true');
 
           done();
         });
@@ -139,10 +144,17 @@ describe('loader integration', function() {
         expect(loaded.scripts[3]).to.match(/require.js$/);
         expect(loaded.scripts[4]).to.match(/exec.js$/);
 
-        expect(loaded.log).to.eql([
-          '_: true Handlebars: true',
-          'App: _: true Handlebars: true Vendor: true'
-        ]);
+
+        // The root-level webpack module should always run first.
+        expect(loaded.log[0]).to.eql("circus module dependency should be first");
+
+        // The logs below are added within functions that run asynchronously at about
+        // the same time.  Since order may not be deterministic, just assert that both
+        // are present by the time things wrap up.
+        expect(loaded.log)
+          .to.contain('_: true Handlebars: true').and
+          .to.contain('App: _: true Handlebars: true Vendor: true');
+
 
         done();
       });


### PR DESCRIPTION
Only one of f9d041a or 8fe6745 are necessary - either one will fix the broken tests.  My preference would be the latter, but I'll leave that up to you.  Let me know which one you prefer and I'll squash before this is merged.

Although this turned out to be a simple fix after a long rabbit hole, it was a beneficial introduction to circus and how you're going about things!  I have some questions and some feedback, but I'll send that separately.

@kpdecker 